### PR TITLE
Fix missing `datajoint` package issue for new users

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pandas==0.25.3
 datajoint
 matplotlib==3.1.3
 seaborn


### PR DESCRIPTION
Currently, [playground.datajoint.io](https://playground.datajoint.io) installs a few packages at the first launch of the `general` server for new users. Looks like there appears to be a conflict with `pandas` that requires it to upgrade which means it needs to recompile the package at install time. This ultimately breaks since the utilities necessary to compile `pandas` are not available. Since this breaks mid-execution, the rest of the provisioning script is not run including `datajoint` installation, config monitoring, etc. This fix is a temporary workaround that allows the install and provisioning process to complete successfully for new users. There are further plans to replace/redeploy the Playground with a proper production release version that will not have such restrictions but until then, this will ensure the current Playground is functional.